### PR TITLE
avoid crash by catching FileNotFoundError in _get_rar_version

### DIFF
--- a/sabnzbd/utils/rarfile.py
+++ b/sabnzbd/utils/rarfile.py
@@ -390,12 +390,15 @@ BSIZE = 32 * 1024
 
 def _get_rar_version(xfile):
     """Check quickly whether file is rar archive."""
-    with XFile(xfile) as fd:
-        buf = fd.read(len(RAR5_ID))
-    if buf.startswith(RAR_ID):
-        return 3
-    elif buf.startswith(RAR5_ID):
-        return 5
+    try:
+        with XFile(xfile) as fd:
+            buf = fd.read(len(RAR5_ID))
+        if buf.startswith(RAR_ID):
+            return 3
+        elif buf.startswith(RAR5_ID):
+            return 5
+    except FileNotFoundError:
+        pass
     return 0
 
 


### PR DESCRIPTION
I've been encountering some sort of race condition where the .par2 file disappears before sabnzbd can get to it and without catching the exception, it causes sabznzbd to crash and restart. With this change, the error is instead logged and no harm is done.